### PR TITLE
startowt.sh: Wait for RabbitMQ to be operational

### DIFF
--- a/docker/startowt.sh
+++ b/docker/startowt.sh
@@ -4,13 +4,20 @@
 cd /home/owt
 
 mongourl=localhost/owtdb
+LOG=/dev/null
 
 service mongodb start &
 service rabbitmq-server start &
 
-while ! mongo --quiet --eval "db.adminCommand('listDatabases')"
+while ! mongo --quiet --eval "db.adminCommand('listDatabases')" >> $LOG 2>&1
 do
-    echo mongo is not ready
+    echo MongoDB is not ready. Waiting...
+    sleep 1
+done
+
+while ! rabbitmqctl -q status >> $LOG 2>&1
+do
+    echo RabbitMQ is not ready. Waiting...
     sleep 1
 done
 


### PR DESCRIPTION
Most of the time, I still see RabbitMQ not up and running after checks for MongoDB complete. So this ensures that both are working before proceeding. Tested and works for me.

Hiding the output just avoids confusing an onlooker that might think there's something wrong, but you might want to do something different.